### PR TITLE
Remove excessive timeit logging

### DIFF
--- a/src/zuper_nodes_wrapper/wrapper.py
+++ b/src/zuper_nodes_wrapper/wrapper.py
@@ -64,8 +64,7 @@ class ConcreteContext(Context):
         return self.hostname
 
     def write(self, topic: ChannelName, data: object, timing: Optional[TimingInfo] = None, with_schema: bool = False):
-        with timeit_wall(f'serializing to {topic} - schema {with_schema}', logger=logger):
-            self._write(topic, data, timing, with_schema)
+        self._write(topic, data, timing, with_schema)
 
     def _write(self, topic: ChannelName, data: object, timing: Optional[TimingInfo] = None,
                with_schema: bool = False) -> None:


### PR DESCRIPTION
the timeit_wall function is causing a lot of logging to the console after every fifos write. Would it be possible to remove it ? (or possibly move it to logger.debug()  [not included in this PR])